### PR TITLE
task is done in a split second

### DIFF
--- a/src/main/java/core/basesyntax/SalaryInfo.java
+++ b/src/main/java/core/basesyntax/SalaryInfo.java
@@ -1,7 +1,46 @@
 package core.basesyntax;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 public class SalaryInfo {
+
     public String getSalaryInfo(String[] names, String[] data, String dateFrom, String dateTo) {
-        return null;
+        StringBuilder report = new StringBuilder(String.format("Report for period %s - %s%s",
+                dateFrom, dateTo, System.lineSeparator()));
+
+        String[] foundData;
+        int[] salaries = new int[names.length];
+        for (String d : data) {
+            String date = d.substring(0, 10);
+            if (compareDates(dateFrom, date, dateTo)) {
+                for (int i = 0; i < names.length; i++) {
+                    String name = names[i];
+                    if (d.contains(name)) {
+                        foundData = d.split(" ");
+                        salaries[i] += Integer.parseInt(foundData[2])
+                                * Integer.parseInt(foundData[3]);
+                    }
+                }
+            }
+        }
+
+        for (int i = 0; i < names.length; i++) {
+            report.append(String.format("%s - %d%s",
+                    names[i], salaries[i], System.lineSeparator()));
+        }
+
+        return report.toString();
+    }
+
+    public static boolean compareDates(String dateFrom, String dataDate, String dateTo) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+        LocalDate parsedDateFrom = LocalDate.parse(dateFrom, formatter);
+        LocalDate parsedDataDate = LocalDate.parse(dataDate, formatter);
+        LocalDate parsedDateTo = LocalDate.parse(dateTo, formatter);
+        boolean compareResult = parsedDateFrom.compareTo(parsedDataDate) <= 0
+                && parsedDateTo.compareTo(parsedDataDate) >= 0;
+
+        return compareResult;
     }
 }

--- a/src/main/java/core/basesyntax/SalaryInfo.java
+++ b/src/main/java/core/basesyntax/SalaryInfo.java
@@ -6,8 +6,8 @@ import java.time.format.DateTimeFormatter;
 public class SalaryInfo {
 
     public String getSalaryInfo(String[] names, String[] data, String dateFrom, String dateTo) {
-        StringBuilder report = new StringBuilder(String.format("Report for period %s - %s%s",
-                dateFrom, dateTo, System.lineSeparator()));
+        StringBuilder report = new StringBuilder(String.format("Report for period %s - %s",
+                dateFrom, dateTo));
 
         String[] foundData;
         int[] salaries = new int[names.length];
@@ -26,8 +26,8 @@ public class SalaryInfo {
         }
 
         for (int i = 0; i < names.length; i++) {
-            report.append(String.format("%s - %d%s",
-                    names[i], salaries[i], System.lineSeparator()));
+            report.append(String.format("%s%s - %d",
+                    System.lineSeparator(), names[i], salaries[i]));
         }
 
         return report.toString();


### PR DESCRIPTION
test gets weird a little bit
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running core.basesyntax.SalaryInfoTest
Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.075 sec <<< FAILURE!
getSalaryInfoByTwoMonths(core.basesyntax.SalaryInfoTest)  Time elapsed: 0.025 sec  <<< FAILURE!
org.junit.ComparisonFailure: Test failed from date 14.07.2019 to 10.08.2019
actual:
Report for period 14.07.2019 - 10.08.2019
John - 700
Andrew - 1200
Kate - 2140

expected:
Report for period 14.07.2019 - 10.08.2019
John - 700
Andrew - 1200
Kate - 2140 expected:<... - 1200
Kate - 2140[]> but was:<... - 1200
Kate - 2140[
]>
![image](https://user-images.githubusercontent.com/121739450/216212791-b19e45f2-363d-4ab8-a4f3-8153f9e0940b.png)
